### PR TITLE
src/program.rs: fix generation of egg terms

### DIFF
--- a/src/program.rs
+++ b/src/program.rs
@@ -63,7 +63,10 @@ impl Term {
             Term::Invocation(f, args) => {
                 let mut s = String::from("(");
                 s.push_str(&f.name);
-                args.iter().for_each(|a| s.push_str(&a.to_egg()));
+                args.iter().for_each(|a| {
+                    s.push_str(" ");
+                    s.push_str(&a.to_egg())
+                });
                 s.push(')');
                 s
             }


### PR DESCRIPTION
Generated terms would have their function name and arguments concatenated without any spaces in between.